### PR TITLE
Always show current timestamp on graph, center graph on event or message hover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "th2-rpt-viewer",
-	"version": "3.0.64",
+	"version": "3.0.65",
 	"description": "",
 	"main": "index.tsx",
 	"private": true,

--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -169,6 +169,7 @@ const GraphRoot = () => {
 				<GraphSearch
 					onTimestampSubmit={activeWorkspace.onTimestampSelect}
 					onFoundItemClick={activeWorkspace.onSavedItemSelect}
+					windowRange={isWorkspaceStore(activeWorkspace) ? activeWorkspace.graphStore.range : null}
 				/>
 				{isWorkspaceStore(activeWorkspace) && <ObservedGraph activeWorkspace={activeWorkspace} />}
 			</div>

--- a/src/components/graph/search/GraphSearch.tsx
+++ b/src/components/graph/search/GraphSearch.tsx
@@ -18,6 +18,7 @@ import * as React from 'react';
 import moment from 'moment';
 import { createBemElement } from '../../../helpers/styleCreators';
 import { useOutsideClickListener } from '../../../hooks/useOutsideClickListener';
+import { TimeRange } from '../../../models/Timestamp';
 import GraphSearchDialog from './GraphSearchDialog';
 import WorkspaceStore from '../../../stores/workspace/WorkspaceStore';
 import { ModalPortal } from '../../util/Portal';
@@ -28,12 +29,13 @@ import KeyCodes from '../../../util/KeyCodes';
 interface Props {
 	onTimestampSubmit: (timestamp: number) => void;
 	onFoundItemClick: InstanceType<typeof WorkspaceStore>['onSavedItemSelect'];
+	windowRange: TimeRange | null;
 }
 
 export type GraphSearchMode = 'date' | 'id';
 
 function GraphSearch(props: Props) {
-	const { onTimestampSubmit, onFoundItemClick } = props;
+	const { onTimestampSubmit, onFoundItemClick, windowRange } = props;
 
 	const [inputConfig, setInputConfig] = React.useState<GraphSearchInputConfig>({
 		isValidDate: false,
@@ -180,6 +182,7 @@ function GraphSearch(props: Props) {
 				inputConfig={inputConfig}
 				setInputConfig={setInputConfig}
 				mode={mode}
+				windowRange={windowRange}
 			/>
 			<ModalPortal
 				isOpen={showModal}

--- a/src/components/graph/search/GraphSearchInput.tsx
+++ b/src/components/graph/search/GraphSearchInput.tsx
@@ -20,6 +20,7 @@ import KeyCodes from '../../../util/KeyCodes';
 import { usePointerTimestamp } from '../../../contexts/pointerTimestampContext';
 import { GraphSearchMode } from './GraphSearch';
 import { DateTimeMask } from '../../../models/filter/FilterInputs';
+import { TimeRange } from '../../../models/Timestamp';
 
 const TIME_MASK = DateTimeMask.TIME_MASK;
 export const DATE_TIME_MASK = DateTimeMask.DATE_TIME_MASK;
@@ -67,10 +68,19 @@ interface Props {
 	setMode: (mode: GraphSearchMode) => void;
 	inputConfig: GraphSearchInputConfig;
 	setInputConfig: (config: GraphSearchInputConfig) => void;
+	windowRange: TimeRange | null;
 }
 
 function GraphSearchInput(props: Props) {
-	const { timestamp, setTimestamp, setMode, inputConfig, setInputConfig, mode } = props;
+	const {
+		timestamp,
+		setTimestamp,
+		setMode,
+		inputConfig,
+		setInputConfig,
+		mode,
+		windowRange,
+	} = props;
 
 	const pointerTimestamp = usePointerTimestamp();
 
@@ -96,6 +106,21 @@ function GraphSearchInput(props: Props) {
 			});
 		}
 	}, [timestamp]);
+
+	React.useEffect(() => {
+		if (windowRange) {
+			const [from, to] = windowRange;
+			const centerTimestamp = from + (to - from) / 2;
+
+			setInputConfig({
+				isValidDate: true,
+				mask: DATE_TIME_MASK,
+				placeholder: DATE_TIME_PLACEHOLDER,
+				timestamp: centerTimestamp,
+				value: moment.utc(centerTimestamp).format(DATE_TIME_MASK),
+			});
+		}
+	}, [windowRange]);
 
 	React.useEffect(() => {
 		const mask = inputConfig.mask || DATE_TIME_MASK;

--- a/src/components/message/message-card/MessageCard.tsx
+++ b/src/components/message/message-card/MessageCard.tsx
@@ -112,6 +112,17 @@ function MessageCardBase({ message, viewType, setViewType }: Props) {
 		};
 	}, [messagesStore.highlightedMessageId]);
 
+	const hoverMessage = () => {
+		hoverTimeout.current = setTimeout(() => {
+			messagesStore.setHoveredMessage(message);
+		}, 150);
+	};
+
+	const unhoverMessage = () => {
+		if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
+		messagesStore.setHoveredMessage(null);
+	};
+
 	const messageViewTypeSwitchConfig: RadioProps<MessageViewType>[] = React.useMemo(
 		() => [
 			{
@@ -182,17 +193,6 @@ function MessageCardBase({ message, viewType, setViewType }: Props) {
 	);
 
 	const bookmarkIconClass = createBemBlock('bookmark-button', isPinned ? 'pinned' : null);
-
-	const hoverMessage = () => {
-		hoverTimeout.current = setTimeout(() => {
-			messagesStore.setHoveredMessage(message);
-		}, 150);
-	};
-
-	const unhoverMessage = () => {
-		if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
-		messagesStore.setHoveredMessage(null);
-	};
 
 	const renderMessageInfo = () => {
 		if (viewType === MessageViewType.FORMATTED || viewType === MessageViewType.BINARY) {

--- a/src/stores/events/EventsStore.ts
+++ b/src/stores/events/EventsStore.ts
@@ -74,6 +74,8 @@ export default class EventsStore {
 		reaction(() => this.viewStore.flattenedListView, this.onViewChange);
 
 		reaction(() => this.searchStore.scrolledItem, this.onScrolledItemChange);
+
+		reaction(() => this.hoveredEvent, this.onEventHover);
 	}
 
 	@observable.shallow eventTree: EventTree = [];
@@ -444,6 +446,12 @@ export default class EventsStore {
 		}
 
 		return path;
+	};
+
+	private onEventHover = (hoveredEvent: EventTreeNode | null) => {
+		if (hoveredEvent !== null) {
+			this.graphStore.setTimestamp(timestampToNumber(hoveredEvent.startTimestamp));
+		}
 	};
 }
 

--- a/src/stores/messages/MessagesDataProviderStore.ts
+++ b/src/stores/messages/MessagesDataProviderStore.ts
@@ -184,6 +184,11 @@ export default class MessagesDataProviderStore {
 
 			if (this.messagesStore.selectedMessageId) {
 				this.messagesStore.scrollToMessage(this.messagesStore.selectedMessageId?.valueOf());
+			} else {
+				const firstPrevMessage = prevMessages[0];
+				if (firstPrevMessage) {
+					this.messagesStore.scrollToMessage(firstPrevMessage.messageId);
+				}
 			}
 		}
 

--- a/src/stores/messages/MessagesStore.ts
+++ b/src/stores/messages/MessagesStore.ts
@@ -108,6 +108,8 @@ export default class MessagesStore {
 		);
 
 		reaction(() => this.selectedMessageId, this.onSelectedMessageIdChange);
+
+		reaction(() => this.hoveredMessage, this.onMessageHover);
 	}
 
 	@computed
@@ -131,7 +133,7 @@ export default class MessagesStore {
 			return [timestampToNumber(messageFrom.timestamp), timestampToNumber(messageTo.timestamp)];
 		}
 		const timestampTo = this.filterStore.filter.timestampTo || moment().utc().valueOf();
-		return [timestampTo - 30 * 1000, timestampTo];
+		return [timestampTo - 15 * 1000, timestampTo + 15 * 1000];
 	}
 
 	@action
@@ -314,5 +316,11 @@ export default class MessagesStore {
 		this.attachedMessagesSubscription();
 		this.filterStore.dispose();
 		this.dataStore.stopMessagesLoading();
+	};
+
+	private onMessageHover = (hoveredMessage: EventMessage | null) => {
+		if (hoveredMessage !== null) {
+			this.graphStore.setTimestamp(timestampToNumber(hoveredMessage.timestamp));
+		}
 	};
 }


### PR DESCRIPTION
  * Make chunks start relative to start of an hour, so they have consistent from and to time borders
  * Scroll hovered item on graph
  * Always show current timestamp
  * Fix center message not being scrolled on range select
  * Fix range select display and click timestamp are different on a few seconds