### PR TITLE
[TH2-3481] Search time limit works incorrectly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "th2-rpt-viewer",
-	"version": "3.1.138",
+	"version": "3.1.139",
 	"description": "",
 	"main": "index.tsx",
 	"private": true,

--- a/src/components/search-panel/SearchPanelForm.tsx
+++ b/src/components/search-panel/SearchPanelForm.tsx
@@ -170,7 +170,7 @@ const SearchPanelForm = () => {
 		previousTimeLimit: {
 			value:
 				isSearching && !timeLimits.previous && startTimestamp
-					? startTimestamp - progress.previous
+					? startTimestamp - Math.abs(progress.previous)
 					: timeLimits.previous,
 			setValue: nextValue =>
 				updateForm({ timeLimits: { ...form.timeLimits, previous: nextValue } }),


### PR DESCRIPTION
Steps to reproduce:

Set the next Event Search parameters:

Start timestamp = Now;

Left search time limit = infinite;

Search direction = past;

Start the Search

Expected result

The left search time limit decrease during the search is running to the past.

Actual result

The left search time limit increase higher than start timestamp. The error notification appears

Test startTimestamp:  20.02.2022 13:36:45.711