### PR TITLE
[TH2 3702] Bookmarks deleting works incorrectly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "th2-rpt-viewer",
-	"version": "5.0.4",
+	"version": "5.0.5",
 	"description": "",
 	"main": "index.tsx",
 	"private": true,

--- a/src/components/bookmarks/BookmarksPanel.tsx
+++ b/src/components/bookmarks/BookmarksPanel.tsx
@@ -130,7 +130,7 @@ function BookmarksPanel() {
 	}
 
 	function removeSelected() {
-		filteredBookmarks
+		bookmarks
 			.filter(bookmark => selectedBookmarks.includes(bookmark.id))
 			.forEach(bookmark => selectedStore.removeBookmark(bookmark));
 		setSelectedBookmarks([]);
@@ -177,7 +177,7 @@ function BookmarksPanel() {
 					<div className='bookmark-panel-header-actions_right-side'>
 						<Checkbox
 							className='bookmarks-panel-checkbox'
-							checked={selectedBookmarks.length === filteredBookmarks.length}
+							checked={selectedBookmarks.length === bookmarks.length && bookmarks.length !== 0}
 							onChange={selectAll}
 						/>
 					</div>


### PR DESCRIPTION
Steps to reproduce:

1.Create some bookmarks

2.Open Seacrh window

3.Open bookmarks window

4.Choose message

5.Mark several message bookmarks

6.Choose event

7.Mark several event bookmarks

8.Click delete 

Expected result - all marked bookmarks deleted

Actual result - Only event bookmarks deleted

rpt-viewer 5.03 and 5.04, cradle 2203 and 31